### PR TITLE
元csvのidをargumentの末尾に付与する

### DIFF
--- a/client-admin/app/create/api/report.ts
+++ b/client-admin/app/create/api/report.ts
@@ -18,6 +18,7 @@ export async function createReport({
   is_pubcom,
   inputType,
   is_embedded_at_local,
+  append_comment_id_to_argument,
   local_llm_address,
 }: {
   input: string;
@@ -32,6 +33,7 @@ export async function createReport({
   is_pubcom: boolean;
   inputType: string;
   is_embedded_at_local: boolean;
+  append_comment_id_to_argument: boolean;
   local_llm_address?: string;
 }): Promise<void> {
   try {
@@ -54,6 +56,7 @@ export async function createReport({
         is_pubcom,
         inputType,
         is_embedded_at_local,
+        append_comment_id_to_argument,
         local_llm_address,
       }),
     });

--- a/client-admin/app/create/components/AISettingsSection.tsx
+++ b/client-admin/app/create/components/AISettingsSection.tsx
@@ -9,12 +9,14 @@ export function AISettingsSection({
   model,
   workers,
   isPubcomMode,
+  appendCommentIdToArgument,
   onProviderChange,
   onModelChange,
   onWorkersChange,
   onIncreaseWorkers,
   onDecreaseWorkers,
   onPubcomModeChange,
+  onAppendCommentIdToArgumentChange,
   getModelDescription,
   getProviderDescription,
   getCurrentModels,
@@ -31,12 +33,14 @@ export function AISettingsSection({
   model: string;
   workers: number;
   isPubcomMode: boolean;
+  appendCommentIdToArgument: boolean;
   onProviderChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   onModelChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   onWorkersChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onIncreaseWorkers: () => void;
   onDecreaseWorkers: () => void;
   onPubcomModeChange: (checked: boolean | "indeterminate") => void;
+  onAppendCommentIdToArgumentChange: (checked: boolean | "indeterminate") => void;
   getModelDescription: () => string;
   getProviderDescription: () => string;
   getCurrentModels: () => { value: string; label: string }[];
@@ -169,6 +173,22 @@ export function AISettingsSection({
               ※ LocalLLMプロバイダーを選択している場合、この設定は強制的にONになります
             </span>
           )}
+        </Field.HelperText>
+      </Field.Root>
+
+      <Field.Root>
+        <Checkbox
+          checked={appendCommentIdToArgument}
+          onCheckedChange={(details) => {
+            const { checked } = details;
+            if (checked === "indeterminate") return;
+            onAppendCommentIdToArgumentChange(checked);
+          }}
+        >
+          コメントIDをテキストの末尾で表示する
+        </Checkbox>
+        <Field.HelperText>
+         ONにした場合は、レポートの散布図上で各テキストの末尾でIDが表示されます。Github のPR分析など、元データとのひも付けをしたい場合はONにしてください。
         </Field.HelperText>
       </Field.Root>
 

--- a/client-admin/app/create/hooks/useAISettings.ts
+++ b/client-admin/app/create/hooks/useAISettings.ts
@@ -21,6 +21,7 @@ const STORAGE_KEYS = {
   WORKERS: `${STORAGE_KEY_PREFIX}workers`,
   LOCAL_LLM_ADDRESS: `${STORAGE_KEY_PREFIX}local_llm_address`,
   IS_EMBEDDED_AT_LOCAL: `${STORAGE_KEY_PREFIX}is_embedded_at_local`,
+  APPEND_COMMENT_ID_TO_ARGUMENT: `${STORAGE_KEY_PREFIX}append_comment_id_to_argument`,
 };
 
 // LocalLLMのデフォルトアドレスを定数化
@@ -113,6 +114,9 @@ export function useAISettings() {
   const [isEmbeddedAtLocal, setIsEmbeddedAtLocal] = useState<boolean>(() =>
     getFromStorage<boolean>(STORAGE_KEYS.IS_EMBEDDED_AT_LOCAL, false),
   );
+  const [appendCommentIdToArgument, setAppendCommentIdToArgument] = useState<boolean>(() =>
+    getFromStorage<boolean>(STORAGE_KEYS.APPEND_COMMENT_ID_TO_ARGUMENT, false),
+  );
 
   const [localLLMAddress, setLocalLLMAddress] = useState<string>(() =>
     getFromStorage<string>(STORAGE_KEYS.LOCAL_LLM_ADDRESS, DEFAULT_LOCAL_LLM_ADDRESS),
@@ -140,6 +144,10 @@ export function useAISettings() {
   useEffect(() => {
     saveToStorage(STORAGE_KEYS.IS_EMBEDDED_AT_LOCAL, isEmbeddedAtLocal);
   }, [isEmbeddedAtLocal]);
+
+  useEffect(() => {
+    saveToStorage(STORAGE_KEYS.APPEND_COMMENT_ID_TO_ARGUMENT, appendCommentIdToArgument);
+  }, [appendCommentIdToArgument]);
 
   useEffect(() => {
     if (provider === "openrouter") {
@@ -259,6 +267,14 @@ export function useAISettings() {
   };
 
   /**
+   * コメントID付与設定変更時のハンドラー
+   */
+  const handleAppendCommentIdToArgumentChange = (checked: boolean | "indeterminate") => {
+    if (checked === "indeterminate") return;
+    setAppendCommentIdToArgument(checked);
+  };
+
+  /**
    * モデル説明文を取得
    */
   const getModelDescription = () => {
@@ -314,6 +330,7 @@ export function useAISettings() {
     setWorkers(30);
     setIsPubcomMode(true);
     setIsEmbeddedAtLocal(false);
+    setAppendCommentIdToArgument(false);
     setLocalLLMAddress(DEFAULT_LOCAL_LLM_ADDRESS);
     setOpenRouterModels([]);
     setLocalLLMModels([]);
@@ -323,6 +340,7 @@ export function useAISettings() {
     saveToStorage(STORAGE_KEYS.WORKERS, 30);
     saveToStorage(STORAGE_KEYS.LOCAL_LLM_ADDRESS, DEFAULT_LOCAL_LLM_ADDRESS);
     saveToStorage(STORAGE_KEYS.IS_EMBEDDED_AT_LOCAL, false);
+    saveToStorage(STORAGE_KEYS.APPEND_COMMENT_ID_TO_ARGUMENT, false);
   };
 
   return {
@@ -331,6 +349,7 @@ export function useAISettings() {
     workers,
     isPubcomMode,
     isEmbeddedAtLocal,
+    appendCommentIdToArgument,
     localLLMAddress,
     handleProviderChange,
     handleModelChange,
@@ -338,6 +357,7 @@ export function useAISettings() {
     increaseWorkers,
     decreaseWorkers,
     handlePubcomModeChange,
+    handleAppendCommentIdToArgumentChange,
     setLocalLLMAddress,
     getModelDescription,
     getProviderDescription,

--- a/client-admin/app/create/page.tsx
+++ b/client-admin/app/create/page.tsx
@@ -83,9 +83,10 @@ export default function Page() {
         const parsed = await parseCsv(inputData.csv);
         comments = parsed.map((row, index) => {
           const rowData = row as unknown as Record<string, unknown>;
+          
           // コメントオブジェクトの作成（基本フィールド）
           const comment: CsvData = {
-            id: `csv-${index + 1}`,
+            id: row.id || `csv-${index + 1}`,
             comment: rowData[inputData.selectedCommentColumn] as string,
             source: null,
             url: null,
@@ -164,6 +165,7 @@ export default function Page() {
         is_pubcom: aiSettings.isPubcomMode,
         inputType: inputData.inputType,
         is_embedded_at_local: aiSettings.isEmbeddedAtLocal,
+        append_comment_id_to_argument: aiSettings.appendCommentIdToArgument,
         local_llm_address: aiSettings.provider === "local" ? aiSettings.localLLMAddress : undefined,
       });
 
@@ -267,6 +269,7 @@ export default function Page() {
               model={aiSettings.model}
               workers={aiSettings.workers}
               isPubcomMode={aiSettings.isPubcomMode}
+              appendCommentIdToArgument={aiSettings.appendCommentIdToArgument}
               isEmbeddedAtLocal={aiSettings.isEmbeddedAtLocal}
               localLLMAddress={aiSettings.localLLMAddress}
               onProviderChange={aiSettings.handleProviderChange}
@@ -281,6 +284,7 @@ export default function Page() {
               onIncreaseWorkers={aiSettings.increaseWorkers}
               onDecreaseWorkers={aiSettings.decreaseWorkers}
               onPubcomModeChange={aiSettings.handlePubcomModeChange}
+              onAppendCommentIdToArgumentChange={aiSettings.handleAppendCommentIdToArgumentChange}
               onEmbeddedAtLocalChange={(checked) => {
                 if (checked === "indeterminate") return;
                 aiSettings.setIsEmbeddedAtLocal(checked);

--- a/client-admin/app/create/parseCsv.ts
+++ b/client-admin/app/create/parseCsv.ts
@@ -1,7 +1,6 @@
 import * as chardet from "chardet";
 import * as iconv from "iconv-lite";
 import Papa from "papaparse";
-import { v4 } from "uuid";
 
 export interface CsvData {
   id: string;
@@ -31,10 +30,21 @@ export async function parseCsv(csvFile: File): Promise<CsvData[]> {
         skipEmptyLines: true,
         complete: (results) => {
           const data = results.data as CsvData[];
-          const converted = data.map((row) => ({
-            ...row,
-            id: v4(),
-          }));
+          const converted = data.map((row, index) => {
+            // id または comment-id が存在する場合はその値を使用、存在しない場合は csv-${index + 1} を使用
+            let finalId = `csv-${index + 1}`;
+            
+            if (row.id !== undefined && row.id !== null && row.id !== '') {
+              finalId = String(row.id);
+            } else if (row['comment-id'] !== undefined && row['comment-id'] !== null && row['comment-id'] !== '') {
+              finalId = String(row['comment-id']);
+            }
+            
+            return {
+              ...row,
+              id: finalId,
+            };
+          });
           resolve(converted);
         },
         error: (error: Error) => {

--- a/server/broadlistening/pipeline/hierarchical_utils.py
+++ b/server/broadlistening/pipeline/hierarchical_utils.py
@@ -37,6 +37,7 @@ def validate_config(config):
         "is_embedded_at_local",
         "provider",
         "local_llm_address",
+        "append_comment_id_to_argument",
     ]
     step_names = [x["step"] for x in specs]
     for key in config:

--- a/server/src/schemas/admin_report.py
+++ b/server/src/schemas/admin_report.py
@@ -36,6 +36,9 @@ class ReportInput(SchemaBaseModel):
     provider: str = "openai"  # LLMプロバイダー（openai, azure, openrouter, local）
     local_llm_address: str | None = None  # LocalLLM用アドレス（例: "127.0.0.1:1234"）
 
+    # NOTE: team-mirai feature
+    append_comment_id_to_argument: bool = False  # コメントIDをargumentに付与するかどうか。付与する場合はtrue
+
 
 class ReportVisibilityUpdate(SchemaBaseModel):
     """レポートの可視性更新用スキーマ"""

--- a/server/src/services/report_launcher.py
+++ b/server/src/services/report_launcher.py
@@ -5,14 +5,10 @@ from pathlib import Path
 from typing import Any
 
 import pandas as pd
-
 from src.config import settings
 from src.schemas.admin_report import ReportInput
-from src.services.report_status import (
-    add_new_report_to_status,
-    set_status,
-    update_token_usage,
-)
+from src.services.report_status import (add_new_report_to_status, set_status,
+                                        update_token_usage)
 from src.services.report_sync import ReportSyncService
 from src.utils.logger import setup_logger
 
@@ -54,6 +50,7 @@ def _build_config(report_input: ReportInput) -> dict[str, Any]:
         "hierarchical_aggregation": {
             "sampling_num": report_input.workers,
         },
+        "append_comment_id_to_argument": report_input.append_comment_id_to_argument,
     }
     return config
 


### PR DESCRIPTION
# 変更の概要
* 元csvのidをargumentの末尾に付与する機能を実装
* 当該機能はoptional
  * 管理画面でチェックをつけた場合のみ適用

# スクリーンショット

地図上での設定
![image](https://github.com/user-attachments/assets/fcc94974-9747-4a21-9871-01574bb908e3)

管理画面の設定
![image](https://github.com/user-attachments/assets/eee4da41-57ce-4cd4-86ad-56d6bb870004)


# 変更の背景
散布図に表示されている意見が、どの元コメントに由来するのかを確認したいケースがある。
例えば、下記のcsvデータはidobataのpull requestが元データになっており、 `id` カラムはpull requestの番号となっている。
番号がわかれば元データ（PR）をたどることができるので、argumentの末尾にidを付与するオプションを追加
https://github.com/team-mirai/random/tree/devin/1747880446-generate-pr-csv/pr_analysis_results/merged



# 動作確認の結果
<!-- 実装者は動作確認の結果を記載してください（例: レポート作成を実行し、正常にレポートが作成されることを確認した） 複数の動作確認を行った場合は、それぞれの結果を記載してください -->

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。