### PR TITLE
全体図でクリックした際にリンク先に飛ばす

### DIFF
--- a/client-admin/app/create/api/report.ts
+++ b/client-admin/app/create/api/report.ts
@@ -18,7 +18,7 @@ export async function createReport({
   is_pubcom,
   inputType,
   is_embedded_at_local,
-  append_comment_id_to_argument,
+  enable_source_link,
   local_llm_address,
 }: {
   input: string;
@@ -33,7 +33,7 @@ export async function createReport({
   is_pubcom: boolean;
   inputType: string;
   is_embedded_at_local: boolean;
-  append_comment_id_to_argument: boolean;
+  enable_source_link: boolean;
   local_llm_address?: string;
 }): Promise<void> {
   try {
@@ -56,7 +56,7 @@ export async function createReport({
         is_pubcom,
         inputType,
         is_embedded_at_local,
-        append_comment_id_to_argument,
+        enable_source_link,
         local_llm_address,
       }),
     });

--- a/client-admin/app/create/components/AISettingsSection.tsx
+++ b/client-admin/app/create/components/AISettingsSection.tsx
@@ -9,14 +9,14 @@ export function AISettingsSection({
   model,
   workers,
   isPubcomMode,
-  appendCommentIdToArgument,
+  enableSourceLink,
   onProviderChange,
   onModelChange,
   onWorkersChange,
   onIncreaseWorkers,
   onDecreaseWorkers,
   onPubcomModeChange,
-  onAppendCommentIdToArgumentChange,
+  onEnableSourceLinkChange,
   getModelDescription,
   getProviderDescription,
   getCurrentModels,
@@ -33,14 +33,14 @@ export function AISettingsSection({
   model: string;
   workers: number;
   isPubcomMode: boolean;
-  appendCommentIdToArgument: boolean;
+  enableSourceLink: boolean;
   onProviderChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   onModelChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
   onWorkersChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onIncreaseWorkers: () => void;
   onDecreaseWorkers: () => void;
   onPubcomModeChange: (checked: boolean | "indeterminate") => void;
-  onAppendCommentIdToArgumentChange: (checked: boolean | "indeterminate") => void;
+  onEnableSourceLinkChange: (checked: boolean | "indeterminate") => void;
   getModelDescription: () => string;
   getProviderDescription: () => string;
   getCurrentModels: () => { value: string; label: string }[];
@@ -178,17 +178,17 @@ export function AISettingsSection({
 
       <Field.Root>
         <Checkbox
-          checked={appendCommentIdToArgument}
+          checked={enableSourceLink}
           onCheckedChange={(details) => {
             const { checked } = details;
             if (checked === "indeterminate") return;
-            onAppendCommentIdToArgumentChange(checked);
+            onEnableSourceLinkChange(checked);
           }}
         >
-          コメントIDをテキストの末尾で表示する
+          ソースリンク機能を有効にする
         </Checkbox>
         <Field.HelperText>
-         ONにした場合は、レポートの散布図上で各テキストの末尾でIDが表示されます。Github のPR分析など、元データとのひも付けをしたい場合はONにしてください。
+         ONにした場合は、CSVのurlカラムの情報を使って、レポートの散布図上でデータ点をクリックすると元のソースにアクセスできます。
         </Field.HelperText>
       </Field.Root>
 

--- a/client-admin/app/create/hooks/useAISettings.ts
+++ b/client-admin/app/create/hooks/useAISettings.ts
@@ -21,7 +21,7 @@ const STORAGE_KEYS = {
   WORKERS: `${STORAGE_KEY_PREFIX}workers`,
   LOCAL_LLM_ADDRESS: `${STORAGE_KEY_PREFIX}local_llm_address`,
   IS_EMBEDDED_AT_LOCAL: `${STORAGE_KEY_PREFIX}is_embedded_at_local`,
-  APPEND_COMMENT_ID_TO_ARGUMENT: `${STORAGE_KEY_PREFIX}append_comment_id_to_argument`,
+  ENABLE_SOURCE_LINK: `${STORAGE_KEY_PREFIX}enable_source_link`,
 };
 
 // LocalLLMのデフォルトアドレスを定数化
@@ -114,8 +114,8 @@ export function useAISettings() {
   const [isEmbeddedAtLocal, setIsEmbeddedAtLocal] = useState<boolean>(() =>
     getFromStorage<boolean>(STORAGE_KEYS.IS_EMBEDDED_AT_LOCAL, false),
   );
-  const [appendCommentIdToArgument, setAppendCommentIdToArgument] = useState<boolean>(() =>
-    getFromStorage<boolean>(STORAGE_KEYS.APPEND_COMMENT_ID_TO_ARGUMENT, false),
+  const [enableSourceLink, setEnableSourceLink] = useState<boolean>(() =>
+    getFromStorage<boolean>(STORAGE_KEYS.ENABLE_SOURCE_LINK, false),
   );
 
   const [localLLMAddress, setLocalLLMAddress] = useState<string>(() =>
@@ -146,8 +146,8 @@ export function useAISettings() {
   }, [isEmbeddedAtLocal]);
 
   useEffect(() => {
-    saveToStorage(STORAGE_KEYS.APPEND_COMMENT_ID_TO_ARGUMENT, appendCommentIdToArgument);
-  }, [appendCommentIdToArgument]);
+    saveToStorage(STORAGE_KEYS.ENABLE_SOURCE_LINK, enableSourceLink);
+  }, [enableSourceLink]);
 
   useEffect(() => {
     if (provider === "openrouter") {
@@ -267,11 +267,11 @@ export function useAISettings() {
   };
 
   /**
-   * コメントID付与設定変更時のハンドラー
+   * ソースリンク設定変更時のハンドラー
    */
-  const handleAppendCommentIdToArgumentChange = (checked: boolean | "indeterminate") => {
+  const handleEnableSourceLinkChange = (checked: boolean | "indeterminate") => {
     if (checked === "indeterminate") return;
-    setAppendCommentIdToArgument(checked);
+    setEnableSourceLink(checked);
   };
 
   /**
@@ -330,7 +330,7 @@ export function useAISettings() {
     setWorkers(30);
     setIsPubcomMode(true);
     setIsEmbeddedAtLocal(false);
-    setAppendCommentIdToArgument(false);
+    setEnableSourceLink(false);
     setLocalLLMAddress(DEFAULT_LOCAL_LLM_ADDRESS);
     setOpenRouterModels([]);
     setLocalLLMModels([]);
@@ -340,7 +340,7 @@ export function useAISettings() {
     saveToStorage(STORAGE_KEYS.WORKERS, 30);
     saveToStorage(STORAGE_KEYS.LOCAL_LLM_ADDRESS, DEFAULT_LOCAL_LLM_ADDRESS);
     saveToStorage(STORAGE_KEYS.IS_EMBEDDED_AT_LOCAL, false);
-    saveToStorage(STORAGE_KEYS.APPEND_COMMENT_ID_TO_ARGUMENT, false);
+    saveToStorage(STORAGE_KEYS.ENABLE_SOURCE_LINK, false);
   };
 
   return {
@@ -349,7 +349,7 @@ export function useAISettings() {
     workers,
     isPubcomMode,
     isEmbeddedAtLocal,
-    appendCommentIdToArgument,
+    enableSourceLink,
     localLLMAddress,
     handleProviderChange,
     handleModelChange,
@@ -357,7 +357,7 @@ export function useAISettings() {
     increaseWorkers,
     decreaseWorkers,
     handlePubcomModeChange,
-    handleAppendCommentIdToArgumentChange,
+    handleEnableSourceLinkChange,
     setLocalLLMAddress,
     getModelDescription,
     getProviderDescription,

--- a/client-admin/app/create/page.tsx
+++ b/client-admin/app/create/page.tsx
@@ -88,8 +88,8 @@ export default function Page() {
           const comment: CsvData = {
             id: row.id || `csv-${index + 1}`,
             comment: rowData[inputData.selectedCommentColumn] as string,
-            source: null,
-            url: null,
+            source: rowData.source as string || null,
+            url: rowData.url as string || null,
           };
 
           // 選択された属性カラムの値を直接追加（"attribute" プレフィックス付き）

--- a/client-admin/app/create/page.tsx
+++ b/client-admin/app/create/page.tsx
@@ -165,7 +165,7 @@ export default function Page() {
         is_pubcom: aiSettings.isPubcomMode,
         inputType: inputData.inputType,
         is_embedded_at_local: aiSettings.isEmbeddedAtLocal,
-        append_comment_id_to_argument: aiSettings.appendCommentIdToArgument,
+        enable_source_link: aiSettings.enableSourceLink,
         local_llm_address: aiSettings.provider === "local" ? aiSettings.localLLMAddress : undefined,
       });
 
@@ -269,7 +269,7 @@ export default function Page() {
               model={aiSettings.model}
               workers={aiSettings.workers}
               isPubcomMode={aiSettings.isPubcomMode}
-              appendCommentIdToArgument={aiSettings.appendCommentIdToArgument}
+              enableSourceLink={aiSettings.enableSourceLink}
               isEmbeddedAtLocal={aiSettings.isEmbeddedAtLocal}
               localLLMAddress={aiSettings.localLLMAddress}
               onProviderChange={aiSettings.handleProviderChange}
@@ -284,7 +284,7 @@ export default function Page() {
               onIncreaseWorkers={aiSettings.increaseWorkers}
               onDecreaseWorkers={aiSettings.decreaseWorkers}
               onPubcomModeChange={aiSettings.handlePubcomModeChange}
-              onAppendCommentIdToArgumentChange={aiSettings.handleAppendCommentIdToArgumentChange}
+              onEnableSourceLinkChange={aiSettings.handleEnableSourceLinkChange}
               onEmbeddedAtLocalChange={(checked) => {
                 if (checked === "indeterminate") return;
                 aiSettings.setIsEmbeddedAtLocal(checked);

--- a/client/components/charts/ScatterChart.tsx
+++ b/client/components/charts/ScatterChart.tsx
@@ -24,10 +24,6 @@ export function ScatterChart({
   filteredArgumentIds, // フィルター済みIDリスト（フィルター条件に合致する引数のID）
   config,
 }: Props) {
-  // デバッグ用ログ
-  console.log("ScatterChart config:", config);
-  console.log("enable_source_link:", config?.enable_source_link);
-  console.log("arguments with URL:", argumentList.filter(arg => arg.url).length);
   // 全ての引数を表示するため、argumentListをそのまま使用
   // フィルター条件に合致しないものは後で灰色表示する
   const allArguments = argumentList;
@@ -324,11 +320,6 @@ export function ScatterChart({
 
     return result;
   });
-
-  // デバッグ用ログ
-  console.log("clusterDataSets length:", clusterDataSets.length);
-  console.log("plotData length:", plotData.length);
-  console.log("plotData structure:", plotData.map((data, index) => ({ index, hasData: !!data })));
 
   // アノテーションの設定
   const annotations: Partial<Annotations>[] = showClusterLabels

--- a/client/components/charts/ScatterChart.tsx
+++ b/client/components/charts/ScatterChart.tsx
@@ -229,7 +229,11 @@ export function ScatterChart({
               color: Array(matching.length).fill(clusterColorMap[cluster.id]),
               opacity: Array(matching.length).fill(1), // 不透明
             },
-            text: matching.map((arg) => `<b>${cluster.label}</b><br>${arg.argument.replace(/(.{30})/g, "$1<br />")}`),
+            text: matching.map((arg) => {
+              const argumentText = arg.argument.replace(/(.{30})/g, "$1<br />");
+              const urlText = arg.url ? `<br>📋 クリックしてソースを見る` : "";
+              return `<b>${cluster.label}</b><br>${argumentText}${urlText}`;
+            }),
             type: "scattergl",
             hoverinfo: "text",
             hovertemplate: "%{text}<extra></extra>",
@@ -358,7 +362,7 @@ export function ScatterChart({
             } as Partial<Layout>
           }
           useResizeHandler={true}
-          style={{ width: "100%", height: "100%" }}
+          style={{ width: "100%", height: "100%", cursor: "pointer" }}
           config={{
             responsive: true,
             displayModeBar: "hover", // 操作時にツールバーを表示
@@ -367,6 +371,28 @@ export function ScatterChart({
           }}
           onHover={onHover}
           onUpdate={onUpdate}
+          onClick={(data) => {
+            if (data.points && data.points.length > 0) {
+              const point = data.points[0];
+              // ポイントのインデックスから対応するargumentを特定
+              if (point.curveNumber !== undefined && point.pointIndex !== undefined) {
+                // plotDataの構造からargumentを特定
+                const clusterIndex = point.curveNumber;
+                const pointIndex = point.pointIndex;
+                
+                // clusterDataSetsから該当するクラスターとargumentを取得
+                const clusterDataSet = clusterDataSets[clusterIndex];
+                if (clusterDataSet) {
+                  const { matching } = separateDataByFilter(clusterDataSet.cluster);
+                  const argument = matching[pointIndex];
+                  
+                  if (argument && argument.url) {
+                    window.open(argument.url, '_blank', 'noopener,noreferrer');
+                  }
+                }
+              }
+            }
+          }}
         />
       </Box>
     </Box>

--- a/client/components/report/Chart.tsx
+++ b/client/components/report/Chart.tsx
@@ -123,6 +123,7 @@ export function Chart({
             onHover={() => setTimeout(avoidHoverTextCoveringShrinkButton, 500)}
             showClusterLabels={showClusterLabels}
             filteredArgumentIds={filteredArgumentIds}
+            config={result.config}
           />
         )}
         {selectedChart === "treemap" && (
@@ -160,6 +161,7 @@ export function Chart({
             targetLevel={selectedChart === "scatterAll" ? 1 : Math.max(...result.clusters.map((c) => c.level))}
             showClusterLabels={showClusterLabels}
             filteredArgumentIds={filteredArgumentIds}
+            config={result.config}
           />
         )}
       </Box>

--- a/client/type.d.ts
+++ b/client/type.d.ts
@@ -47,6 +47,7 @@ type Argument = {
   p: number; // 追加情報（数値）
   cluster_ids: string[]; // 属するクラスタの ID リスト
   attributes?: Record<string, string | number>; // 属性情報
+  url?: string; // ソースURL（optional）
 };
 
 export type Cluster = {

--- a/client/type.d.ts
+++ b/client/type.d.ts
@@ -38,7 +38,7 @@ export type Result = {
   filteredArgumentIds?: string[]; // フィルターに一致した引数IDのリスト（グレーアウト表示の制御に使用）
 };
 
-type Argument = {
+export type Argument = {
   arg_id: string; // 意見の識別子
   argument: string; // 意見の内容
   comment_id: number; // 関連するコメントの ID
@@ -77,7 +77,7 @@ export type JaLocaleType = {
 
 type Comments = Record<string, { comment: string }>; // コメントIDをキーに持つオブジェクト
 
-type Config = {
+export type Config = {
   name: string; // 設定の名前
   question: string; // AIに関する問い
   input: string; // 入力データの識別子
@@ -86,6 +86,7 @@ type Config = {
   output_dir: string; // 結果の出力ディレクトリ名
   previous?: Config; // 過去の設定情報
   is_embedded_at_local: boolean; // ローカルで埋め込みを生成するかどうか
+  enable_source_link?: boolean; // ソースリンク機能を有効にするかどうか
   extraction: {
     workers: number; // 並列処理数
     limit: number; // データ抽出の上限数

--- a/server/broadlistening/pipeline/hierarchical_utils.py
+++ b/server/broadlistening/pipeline/hierarchical_utils.py
@@ -37,7 +37,7 @@ def validate_config(config):
         "is_embedded_at_local",
         "provider",
         "local_llm_address",
-        "append_comment_id_to_argument",
+        "enable_source_link",
     ]
     step_names = [x["step"] for x in specs]
     for key in config:

--- a/server/broadlistening/pipeline/steps/extraction.py
+++ b/server/broadlistening/pipeline/steps/extraction.py
@@ -25,11 +25,6 @@ def _validate_property_columns(property_columns: list[str], comments: pd.DataFra
 
 
 
-def build_argument(comment_id: str, argument: str, append_comment_id_to_argument: bool) -> str:
-    if append_comment_id_to_argument:
-        # github PR 番号などがidに付与されており、管理画面でid表示がONになっている場合は、#{id}を付与する
-        return f"{argument} #{comment_id}"
-    return argument
 
 
 
@@ -73,7 +68,7 @@ def extraction(config):
                 if arg not in argument_map:
                     # argumentテーブルに追加
                     arg_id = f"A{comment_id}_{j}"
-                    argument = build_argument(comment_id, arg, config["append_comment_id_to_argument"])
+                    argument = arg
                     argument_map[arg] = {
                         "arg-id": arg_id,
                         "argument": argument,

--- a/server/broadlistening/pipeline/steps/hierarchical_aggregation.py
+++ b/server/broadlistening/pipeline/steps/hierarchical_aggregation.py
@@ -84,7 +84,7 @@ def hierarchical_aggregation(config) -> bool:
 
         hidden_properties_map: dict[str, list[str]] = config["hierarchical_aggregation"]["hidden_properties"]
 
-        results["arguments"] = _build_arguments(clusters, comments, relation_df)
+        results["arguments"] = _build_arguments(clusters, comments, relation_df, config)
         results["clusters"] = _build_cluster_value(labels, arg_num)
 
         # results["comments"] = _build_comments_value(
@@ -200,7 +200,7 @@ def add_original_comments(labels, arguments, relation_df, clusters, config):
     final_df.to_csv(PIPELINE_DIR / f"outputs/{config['output_dir']}/final_result_with_comments.csv", index=False)
 
 
-def _build_arguments(clusters: pd.DataFrame, comments: pd.DataFrame, relation_df: pd.DataFrame) -> list[Argument]:
+def _build_arguments(clusters: pd.DataFrame, comments: pd.DataFrame, relation_df: pd.DataFrame, config: dict) -> list[Argument]:
     """
     Build the arguments list including attribute information from original comments
 
@@ -208,6 +208,7 @@ def _build_arguments(clusters: pd.DataFrame, comments: pd.DataFrame, relation_df
         clusters: DataFrame containing cluster information for each argument
         comments: DataFrame containing original comments with attribute columns
         relation_df: DataFrame relating arguments to original comments
+        config: Configuration dictionary containing enable_source_link setting
     """
     cluster_columns = [col for col in clusters.columns if col.startswith("cluster-level-") and "id" in col]
 
@@ -251,8 +252,8 @@ def _build_arguments(clusters: pd.DataFrame, comments: pd.DataFrame, relation_df
             if not comment_rows.empty:
                 comment_row = comment_rows.iloc[0]
                 
-                # Add URL if available
-                if "url" in comment_row and comment_row["url"] is not None:
+                # Add URL if available and enabled
+                if config.get("enable_source_link", False) and "url" in comment_row and comment_row["url"] is not None:
                     argument["url"] = str(comment_row["url"])
                 
                 # Add attributes if available

--- a/server/src/schemas/admin_report.py
+++ b/server/src/schemas/admin_report.py
@@ -37,7 +37,7 @@ class ReportInput(SchemaBaseModel):
     local_llm_address: str | None = None  # LocalLLM用アドレス（例: "127.0.0.1:1234"）
 
     # NOTE: team-mirai feature
-    append_comment_id_to_argument: bool = False  # コメントIDをargumentに付与するかどうか。付与する場合はtrue
+    enable_source_link: bool = False  # ソースリンク機能を有効にするかどうか。有効にする場合はtrue
 
 
 class ReportVisibilityUpdate(SchemaBaseModel):

--- a/server/src/services/report_launcher.py
+++ b/server/src/services/report_launcher.py
@@ -50,7 +50,7 @@ def _build_config(report_input: ReportInput) -> dict[str, Any]:
         "hierarchical_aggregation": {
             "sampling_num": report_input.workers,
         },
-        "append_comment_id_to_argument": report_input.append_comment_id_to_argument,
+        "enable_source_link": report_input.enable_source_link,
     }
     return config
 


### PR DESCRIPTION
# 変更の概要
* 全体・濃い意見において、データ点をクリックした際に紐づくリンク先に飛ばす機能を実装
* 「url」カラムが元csvに存在する場合で、なおかつこのオプションをレポート作成時にONにした場合に活用できる

# スクリーンショット
![fd49864851603ef5a188f4be0ab7eb83](https://github.com/user-attachments/assets/92e4db11-a35b-437c-87d7-fe3613d2d1d3)



# 変更の背景
* 散布図の元データを確認したいケースがある


# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/digitaldemocracy2030/kouchou-ai/blob/main/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました

# マージ前のチェックリスト（レビュアーがマージ前に確認してください）
- [ ] CIが全て通過している
- [ ] 単体テストが実装されているか
- [ ] 今回実装した機能および影響を受けると思われる機能について、適切な動作確認が行われているかを確認する。


動作確認の項目については、実装者による動作確認のケースが適切かを確認してください。
必要に応じてレビュアー自身による動作確認も歓迎します（必須ではありません）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a source link feature that enables clickable points in scatter plots, allowing users to access original sources via URLs if available.

- **Improvements**
  - Updated settings and UI labels to reflect the new source link functionality.
  - Scatter plot points now visually indicate when source links are enabled, including hover prompts and clickable styling.

- **Bug Fixes**
  - CSV data parsing now correctly assigns source and URL fields from data rows.

- **Documentation**
  - Updated helper texts and labels to describe the source link feature.

- **Refactor**
  - Replaced the previous comment ID display option with the new source link feature throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->